### PR TITLE
Feat: convert logline props to labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,18 +16,19 @@ node foo | pino-loki --hostname=http://hostname:3100
 ```
 $ pino-loki -h
 Options:
-  -V, --version              output the version number
-  -u, --user <user>          Loki username
-  -p, --password <password>  Loki password
-  --hostname <hostname>      URL for Loki
-  -b, --batch                Should logs be sent in batch mode
-  -i, --interval <interval>  The interval at which batched logs are sent in seconds
-  -t, --timeout <timeout>    Timeout for request to Loki
-  -s, --silenceErrors        If false, errors will be displayed in the console
-  -r, --replaceTimestamp     Replace pino logs timestamps with Date.now()
-  -l, --labels <label>       Additional labels to be added to all Loki logs
-  --no-stdout                Disable output to stdout
-  -h, --help                 display help for command
+  -V, --version                  output the version number
+  -u, --user <user>              Loki username
+  -p, --password <password>      Loki password
+  --hostname <hostname>          URL for Loki
+  -b, --batch                    Should logs be sent in batch mode
+  -i, --interval <interval>      The interval at which batched logs are sent in seconds
+  -t, --timeout <timeout>        Timeout for request to Loki
+  -s, --silenceErrors            If false, errors will be displayed in the console
+  -r, --replaceTimestamp         Replace pino logs timestamps with Date.now()
+  -l, --labels <label>           Additional labels to be added to all Loki logs
+  -pl, --propsLabels <labels>    Fields in log line to convert to Loki labels (comma separated values)
+  --no-stdout                    Disable output to stdout
+  -h, --help                     display help for command
 ```
 
 ## Programmatic integration

--- a/src/Contracts/index.ts
+++ b/src/Contracts/index.ts
@@ -79,4 +79,9 @@ export interface PinoLokiOptionsContract {
     username: string
     password: string
   }
+
+  /**
+   * Select log message's props to set as Loki labels
+   */
+  propsToLabels?: string[]
 }

--- a/src/LogBuilder/index.ts
+++ b/src/LogBuilder/index.ts
@@ -4,6 +4,11 @@ import { LokiLog, LokiLogLevel, PinoLog } from '../Contracts'
  * Converts a Pino log to a Loki log
  */
 export class LogBuilder {
+  propsToLabel: string[]
+
+  constructor(propsToLabel: string[] = []) {
+    this.propsToLabel = propsToLabel
+  }
   /**
    * Convert a level to a human readable status
    */
@@ -37,12 +42,19 @@ export class LogBuilder {
     if (replaceTimestamp) {
       time = (new Date().getTime() * 1000000).toString()
     }
+    const propsLabels = this.propsToLabel.reduce((acc, current) => {
+      if (log[current]) {
+        acc[current] = log[current]
+      }
+      return acc
+    }, {} as { [key:string]: any})
 
     return {
       stream: {
         level: status,
         hostname,
         ...additionalLabels,
+        ...propsLabels
       },
       values: [[time, JSON.stringify(log)]],
     }

--- a/src/LogPusher/index.ts
+++ b/src/LogPusher/index.ts
@@ -20,8 +20,8 @@ export class LogPusher {
     if (this.options.basicAuth) {
       this.client.defaults.auth = this.options.basicAuth
     }
-
-    this.logBuilder = new LogBuilder()
+    const propsToLabels = options.propsToLabels || []
+    this.logBuilder = new LogBuilder(propsToLabels)
   }
 
   /**

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,7 +19,10 @@ export const parseArgs = () => {
     .option('-s, --silenceErrors', 'If false, errors will be displayed in the console')
     .option('-r, --replaceTimestamp', 'Replace pino logs timestamps with Date.now()')
     .option('-l, --labels <label>', 'Additional labels to be added to all Loki logs')
-    .option('-pl, --propsLabels <label>', 'Fields in log line to convert to Loki labels')
+    .option(
+      '-pl, --propsLabels <labels>',
+      'Fields in log line to convert to Loki labels (comma separated values)'
+    )
     .option('--no-stdout', 'Disable output to stdout')
 
   program.parse(process.argv)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,6 +19,7 @@ export const parseArgs = () => {
     .option('-s, --silenceErrors', 'If false, errors will be displayed in the console')
     .option('-r, --replaceTimestamp', 'Replace pino logs timestamps with Date.now()')
     .option('-l, --labels <label>', 'Additional labels to be added to all Loki logs')
+    .option('-pl, --propsLabels <label>', 'Fields in log line to convert to Loki labels')
     .option('--no-stdout', 'Disable output to stdout')
 
   program.parse(process.argv)
@@ -40,6 +41,7 @@ export const createPinoLokiConfigFromArgs = () => {
     interval: opts.interval,
     replaceTimestamp: opts.replaceTimestamp,
     labels: opts.labels ? JSON.parse(opts.labels) : undefined,
+    propsToLabels: opts.propsLabels ? opts.propsLabels.split(',') : [],
     basicAuth: {
       username: opts.user,
       password: opts.password,

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ export default async function (options: PinoLokiOptionsContract) {
   options.batching ??= true
   options.interval ??= 5
   options.replaceTimestamp ??= false
-
+  options.propsToLabels ??= []
   const logPusher = new LogPusher(options)
 
   return build(async (source: any) => {

--- a/tests/cli.spec.ts
+++ b/tests/cli.spec.ts
@@ -8,4 +8,11 @@ test.group('Cli', () => {
 
     assert.deepEqual(ret.labels, { test: '42', hello: { world: '42' } })
   })
+
+  test('Should set props to labels', ({ assert }) => {
+    process.argv = ['node', 'src/cli.ts', '--propsLabels', `foo,bar`]
+    const ret = createPinoLokiConfigFromArgs()
+
+    assert.deepEqual(ret.propsToLabels, ['foo', 'bar'])
+  })
 })

--- a/tests/log-builder.spec.ts
+++ b/tests/log-builder.spec.ts
@@ -56,4 +56,21 @@ test.group('Log Builder', () => {
 
     assert.closeTo(+lokiLog.values[0][0], +currentTime, 10000000)
   })
+
+  test('Props to label', ({ assert }) => {
+    const logBuilder = new LogBuilder(['appId', 'buildId'])
+
+    const log: PinoLog = {
+      hostname: 'localhost',
+      level: 30,
+      msg: 'hello world',
+      time: new Date(),
+      v: 1,
+      appId: 123,
+      buildId: 'aaaa',
+    }
+    const lokiLog = logBuilder.build(log, true, { application: 'MY-APP' })
+    assert.equal(lokiLog.stream.appId, 123)
+    assert.equal(lokiLog.stream.buildId, 'aaaa')
+  })
 })


### PR DESCRIPTION
Hi! 
I needed this feature and I thought it could be a nice improvement also for others.

This PR let's the user specify some fields of the log line that should be saved as labels in loki.

Signed-off-by: Leonardo Rossi <leonardo.rossi@gmail.com>