### PR TITLE
add support for structured metadata

### DIFF
--- a/src/log_builder.ts
+++ b/src/log_builder.ts
@@ -99,7 +99,9 @@ export class LogBuilder {
 
     const hostname = options.log.hostname
     options.log.hostname = undefined
-
+    const meta = options.log.meta || {}
+    options.log.meta = undefined
+    
     return {
       stream: {
         level: status,
@@ -107,7 +109,7 @@ export class LogBuilder {
         ...options.additionalLabels,
         ...propsLabels,
       },
-      values: [[time, this.#stringifyLog(options.log, options.convertArrays)]],
+      values: [[time, this.#stringifyLog(options.log, options.convertArrays), meta]],
     }
   }
 }


### PR DESCRIPTION
Update log_builder.ts
Added support for for structured metadata https://grafana.com/docs/loki/latest/reference/loki-http-api/#ingest-logs

Now its possible to pass structured metadata as simple as adding object `meta`, e.g.:
```
logger.info({ foo: 'bar', meta: { id: "123456" }}, "hello world");
```