### PR TITLE
Add custom push Loki API path support

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ A map of pino log levels to Loki log levels. This can be used to map pino log le
 
 The URL for Loki. This is required.
 
+#### `pushApiPath`
+
+The path to the Loki push API. Defaults to `/loki/api/v1/push`.
+
 #### `basicAuth`
 
 Basic auth credentials for Loki. An object with the following shape:
@@ -133,6 +137,7 @@ Options:
   -u, --user <user>              Loki username
   -p, --password <password>      Loki password
   --hostname <hostname>          URL for Loki
+  --pushApiPath <pushApiPath>    Path to the Loki push API
   -b, --batch                    Should logs be sent in batch mode
   -i, --interval <interval>      The interval at which batched logs are sent in seconds
   -t, --timeout <timeout>        Timeout for request to Loki

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ A map of pino log levels to Loki log levels. This can be used to map pino log le
 
 The URL for Loki. This is required.
 
-#### `pushApiPath`
+#### `endpoint`
 
 The path to the Loki push API. Defaults to `/loki/api/v1/push`.
 
@@ -137,7 +137,7 @@ Options:
   -u, --user <user>              Loki username
   -p, --password <password>      Loki password
   --hostname <hostname>          URL for Loki
-  --pushApiPath <pushApiPath>    Path to the Loki push API
+  --endpoint <endpoint>          Path to the Loki push API
   -b, --batch                    Should logs be sent in batch mode
   -i, --interval <interval>      The interval at which batched logs are sent in seconds
   -t, --timeout <timeout>        Timeout for request to Loki

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,7 +10,7 @@ program
   .option('-u, --user <user>', 'Loki username')
   .option('-p, --password <password>', 'Loki password')
   .option('--hostname <hostname>', 'URL for Loki')
-  .option('--pushApiPath <pushApiPath>', 'Path to the Loki push API')
+  .option('--endpoint <endpoint>', 'Path to the Loki push API')
   .option('-b, --batch', 'Should logs be sent in batch mode')
   .option('-i, --interval <interval>', 'The interval at which batched logs are sent in seconds')
   .option('-t, --timeout <timeout>', 'Timeout for request to Loki')
@@ -33,7 +33,7 @@ export const createPinoLokiConfigFromArgs = () => {
 
   const config: LokiOptions = {
     host: opts.hostname,
-    pushApiPath: opts.pushApiPath,
+    endpoint: opts.endpoint,
     timeout: opts.timeout,
     silenceErrors: opts.silenceErrors,
     batching: opts.batch,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,7 @@ program
   .option('-u, --user <user>', 'Loki username')
   .option('-p, --password <password>', 'Loki password')
   .option('--hostname <hostname>', 'URL for Loki')
+  .option('--pushApiPath <pushApiPath>', 'Path to the Loki push API')
   .option('-b, --batch', 'Should logs be sent in batch mode')
   .option('-i, --interval <interval>', 'The interval at which batched logs are sent in seconds')
   .option('-t, --timeout <timeout>', 'Timeout for request to Loki')
@@ -32,6 +33,7 @@ export const createPinoLokiConfigFromArgs = () => {
 
   const config: LokiOptions = {
     host: opts.hostname,
+    pushApiPath: opts.pushApiPath,
     timeout: opts.timeout,
     silenceErrors: opts.silenceErrors,
     batching: opts.batch,

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import type { PinoLog, LokiOptions } from './types'
 function resolveOptions(options: LokiOptions) {
   return {
     ...options,
-    pushApiPath: options.pushApiPath ?? 'loki/api/v1/push',
+    endpoint: options.endpoint ?? 'loki/api/v1/push',
     timeout: options.timeout ?? 30_000,
     silenceErrors: options.silenceErrors ?? false,
     batching: options.batching ?? true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import type { PinoLog, LokiOptions } from './types'
 function resolveOptions(options: LokiOptions) {
   return {
     ...options,
+    pushApiPath: options.pushApiPath ?? 'loki/api/v1/push',
     timeout: options.timeout ?? 30_000,
     silenceErrors: options.silenceErrors ?? false,
     batching: options.batching ?? true,

--- a/src/log_pusher.ts
+++ b/src/log_pusher.ts
@@ -65,22 +65,25 @@ export class LogPusher {
     debug(`[LogPusher] pushing ${lokiLogs.length} logs to Loki`)
 
     try {
-      const response = await fetch(new URL('loki/api/v1/push', this.#options.host), {
-        method: 'POST',
-        signal: AbortSignal.timeout(this.#options.timeout ?? 30_000),
-        headers: {
-          ...this.#options.headers,
-          ...(this.#options.basicAuth && {
-            Authorization:
-              'Basic ' +
-              Buffer.from(
-                `${this.#options.basicAuth.username}:${this.#options.basicAuth.password}`,
-              ).toString('base64'),
-          }),
-          'Content-Type': 'application/json',
+      const response = await fetch(
+        new URL(this.#options.pushApiPath ?? 'loki/api/v1/push', this.#options.host),
+        {
+          method: 'POST',
+          signal: AbortSignal.timeout(this.#options.timeout ?? 30_000),
+          headers: {
+            ...this.#options.headers,
+            ...(this.#options.basicAuth && {
+              Authorization:
+                'Basic ' +
+                Buffer.from(
+                  `${this.#options.basicAuth.username}:${this.#options.basicAuth.password}`,
+                ).toString('base64'),
+            }),
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ streams: lokiLogs }),
         },
-        body: JSON.stringify({ streams: lokiLogs }),
-      })
+      )
 
       if (!response.ok) {
         throw new RequestError('Got error when trying to send log to loki', await response.text())

--- a/src/log_pusher.ts
+++ b/src/log_pusher.ts
@@ -66,7 +66,7 @@ export class LogPusher {
 
     try {
       const response = await fetch(
-        new URL(this.#options.pushApiPath ?? 'loki/api/v1/push', this.#options.host),
+        new URL(this.#options.endpoint ?? 'loki/api/v1/push', this.#options.host),
         {
           method: 'POST',
           signal: AbortSignal.timeout(this.#options.timeout ?? 30_000),

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,7 +49,7 @@ export interface LokiOptions {
    *
    * @default loki/api/v1/push
    */
-  pushApiPath?: string
+  endpoint?: string
 
   /**
    * Timeout for request to Loki

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,13 @@ export interface LokiOptions {
   host: string
 
   /**
+   * Url for Loki push API
+   *
+   * @default loki/api/v1/push
+   */
+  pushApiPath?: string
+
+  /**
    * Timeout for request to Loki
    *
    * @default 30_000

--- a/tests/unit/log_pusher.spec.ts
+++ b/tests/unit/log_pusher.spec.ts
@@ -9,6 +9,9 @@ test.group('LogPusher', (group) => {
     http.post('http://localhost:3100/loki/api/v1/push', () => {
       return new Response(null, { status: 204 })
     }),
+    http.post('http://localhost:3100/loki/api/v1/push/test', () => {
+      return new Response(null, { status: 204 })
+    }),
   )
 
   group.setup(() => {
@@ -86,5 +89,21 @@ test.group('LogPusher', (group) => {
     assert.isTrue(true)
 
     console.error = consoleError
+  })
+
+  test("should be send logs to Loki's push API if specified", async ({ assert }) => {
+    const pusher = new LogPusher({
+      host: 'http://localhost:3100',
+      pushApiPath: 'loki/api/v1/push/test',
+    })
+
+    let url = ''
+    server.events.on('request:start', ({ request }) => {
+      url = request.url
+    })
+
+    pusher.push({ level: 30 })
+
+    assert.equal(url, 'http://localhost:3100/loki/api/v1/push/test')
   })
 })

--- a/tests/unit/log_pusher.spec.ts
+++ b/tests/unit/log_pusher.spec.ts
@@ -94,7 +94,7 @@ test.group('LogPusher', (group) => {
   test("should be send logs to Loki's push API if specified", async ({ assert }) => {
     const pusher = new LogPusher({
       host: 'http://localhost:3100',
-      pushApiPath: 'loki/api/v1/push/test',
+      endpoint: 'loki/api/v1/push/test',
     })
 
     let url = ''


### PR DESCRIPTION
Hi 👋,

I would like to add the function of configuring the route of the Loki push API. The reason for this is that I am using VictoriaLogs which is compatible with Loki's JSON API, the only thing is that it does not expose the endpoint to put data in the same path as Loki. I think that being able to configure the endpoint where it has to send the data can give the program more versatility.

The truth is that the change is quite urgent for me, so I would appreciate it if you would look at it as soon as possible.

Finally, let me tell you that you have a wonderful library.

Greetings, thank you very much
