### PR TITLE
fix: force to string to satisfy loki api

### DIFF
--- a/src/log_builder.ts
+++ b/src/log_builder.ts
@@ -78,13 +78,25 @@ export class LogBuilder {
     return labels
   }
 
-  #createStructuredMetadata(log: PinoLog, structuredMetaKey?: string): Record<string, any> | undefined {
+  /**
+   * Loki structured metadata requires string values only.
+   */
+  #buildStructuredMetadata(
+    log: PinoLog,
+    structuredMetaKey?: string,
+  ): Record<string, string> | undefined {
     if (!structuredMetaKey) return undefined
 
+    const meta = log[structuredMetaKey]
+    if (!meta || typeof meta !== 'object') return undefined
+
     const result: Record<string, string> = {}
-    for (const [key, value] of Object.entries(log[structuredMetaKey])) {
-      result[key] = typeof value === 'string' ? value : String(value)
+    for (const [key, value] of Object.entries(meta)) {
+      if (typeof value === 'string') result[key] = value
+      else if (typeof value === 'object' && value !== null) result[key] = JSON.stringify(value)
+      else result[key] = String(value)
     }
+
     return result
   }
 
@@ -113,10 +125,7 @@ export class LogBuilder {
     const hostname = options.log.hostname
     options.log.hostname = undefined
 
-    const structuredMetadata = this.#createStructuredMetadata(
-      options.log,
-      options.structuredMetaKey,
-    )
+    const structuredMetadata = this.#buildStructuredMetadata(options.log, options.structuredMetaKey)
 
     const formattedMessage = options.logFormat
       ? formatLog({

--- a/src/log_builder.ts
+++ b/src/log_builder.ts
@@ -113,7 +113,10 @@ export class LogBuilder {
     const hostname = options.log.hostname
     options.log.hostname = undefined
 
-    const structuredMetadata = this.#createStructuredMetadata(options.log, options.structuredMetaKey)
+    const structuredMetadata = this.#createStructuredMetadata(
+      options.log,
+      options.structuredMetaKey,
+    )
 
     const formattedMessage = options.logFormat
       ? formatLog({

--- a/src/log_builder.ts
+++ b/src/log_builder.ts
@@ -78,6 +78,16 @@ export class LogBuilder {
     return labels
   }
 
+  #createStructuredMetadata(log: PinoLog, structuredMetaKey?: string): Record<string, any> | undefined {
+    if (!structuredMetaKey) return undefined
+
+    const result: Record<string, string> = {}
+    for (const [key, value] of Object.entries(log[structuredMetaKey])) {
+      result[key] = typeof value === 'string' ? value : String(value)
+    }
+    return result
+  }
+
   /**
    * Convert a level to a human readable status
    */
@@ -103,9 +113,7 @@ export class LogBuilder {
     const hostname = options.log.hostname
     options.log.hostname = undefined
 
-    const structuredMetadata: Record<string, any> = options.structuredMetaKey
-      ? options.log[options.structuredMetaKey]
-      : undefined
+    const structuredMetadata = this.#createStructuredMetadata(options.log, options.structuredMetaKey)
 
     const formattedMessage = options.logFormat
       ? formatLog({

--- a/tests/unit/log_builder.spec.ts
+++ b/tests/unit/log_builder.spec.ts
@@ -176,10 +176,38 @@ test.group('Log Builder', () => {
     assert.deepEqual(JSON.parse(log.values[0][1]), {
       level: 30,
       msg: 'hello world',
-      metaKey: { foo: 'bar', forceToString: 200 },
+      metaKey: { foo: 'bar' },
     })
 
-    assert.deepEqual(log.values[0][2], { foo: 'bar', forceToString: '200' })
+    assert.deepEqual(log.values[0][2], { foo: 'bar' })
+  })
+
+  test('structured metadata converts non-string values to strings', ({ assert }) => {
+    const logBuilder = new LogBuilder()
+
+    const log = logBuilder.build({
+      log: {
+        level: 30,
+        msg: 'hello world',
+        metaKey: {
+          string: 'bar',
+          number: 200,
+          boolean: true,
+          nested: { deep: 'value' },
+          array: [1, 2, 3],
+        },
+      },
+      replaceTimestamp: true,
+      structuredMetaKey: 'metaKey',
+    })
+
+    assert.deepEqual(log.values[0][2], {
+      string: 'bar',
+      number: '200',
+      boolean: 'true',
+      nested: '{"deep":"value"}',
+      array: '[1,2,3]',
+    })
   })
 
   test('does not include structured metadata when not set', ({ assert }) => {

--- a/tests/unit/log_builder.spec.ts
+++ b/tests/unit/log_builder.spec.ts
@@ -176,10 +176,10 @@ test.group('Log Builder', () => {
     assert.deepEqual(JSON.parse(log.values[0][1]), {
       level: 30,
       msg: 'hello world',
-      metaKey: { foo: 'bar' },
+      metaKey: { foo: 'bar', forceToString: 200 },
     })
 
-    assert.deepEqual(log.values[0][2], { foo: 'bar' })
+    assert.deepEqual(log.values[0][2], { foo: 'bar', forceToString: '200' })
   })
 
   test('does not include structured metadata when not set', ({ assert }) => {


### PR DESCRIPTION
<img width="1797" height="1103" alt="image" src="https://github.com/user-attachments/assets/6bdc02f6-6b77-4992-a409-2a608f030dd6" />


## Reproduce
Input any non string value in metadata key
```
logger.info({ meta: { statusCode: 200 } }, "Loki support only string in structured metadata")
```

## Error
```
loghttp.PushRequest.Streams: []loghttp.LogProtoStream: unmarshalerDecoder: Value is string, but can't find closing '"' symbol, error found in #10 byte of ...|e":200}]]}]}|..., bigger context ...|ring in structured metadata",{"statusCode":200}]]}]}|...
```

Based on this document 
https://grafana.com/docs/loki/latest/reference/loki-http-api/#ingest-logs

> The JSON object must be a valid JSON object with `string keys` and `string values`. The JSON object should not contain any nested object. The JSON object must be set immediately after the log line.

I think it's better to transform to string for user instead of leave it error