### PR TITLE
feat: automatically use EnvHttpProxyAgent for HTTP-proxy support

### DIFF
--- a/src/log_pusher.ts
+++ b/src/log_pusher.ts
@@ -1,6 +1,7 @@
 import debug from './debug.ts'
 import { LogBuilder } from './log_builder.ts'
 import type { PinoLog, LokiOptions } from './types.ts'
+import { Dispatcher, EnvHttpProxyAgent } from "undici";
 
 class RequestError extends Error {
   responseBody: string
@@ -18,9 +19,11 @@ class RequestError extends Error {
 export class LogPusher {
   #options: LokiOptions
   #logBuilder: LogBuilder
+  #agent: Dispatcher
 
   constructor(options: LokiOptions) {
     this.#options = options
+    this.#agent = new EnvHttpProxyAgent() // for automatic HTTP-proxy support
 
     this.#logBuilder = new LogBuilder({
       levelMap: options.levelMap,
@@ -83,6 +86,7 @@ export class LogPusher {
             'Content-Type': 'application/json',
           },
           body: JSON.stringify({ streams: lokiLogs }),
+          dispatcher: this.#agent,
         },
       )
 


### PR DESCRIPTION
This patch makes `pino-loki` automatically detect proxy settings from the environment variables (`HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY`) using `undici`'s `EnvHttpProxyAgent`. This ensures that logs are correctly sent in corporate network environments without requiring manual dispatcher injection.

**Background:**
Before this patch, there was no way to pass a proxy/agent to `pino‑loki`’s HTTP implementation.

Node’s native `fetch()` does not currently pick up `undici.setGlobalDispatcher()` when fetch is invoked — especially in Node 20/22 where `fetch` is backed by the built‑in `undici`.

This patch closes that gap and makes `pino‑loki` usable in proxied environments without workarounds.